### PR TITLE
Wrap SIGHUP/SIGINT/SIGKILL listening in try/catch

### DIFF
--- a/cluster-master.js
+++ b/cluster-master.js
@@ -251,9 +251,14 @@ function quit () {
 
 
 function setupSignals () {
-  process.on("SIGHUP", restart)
-  process.on("SIGINT", quit)
-  process.on("SIGKILL", quitHard)
+  try {
+    process.on("SIGHUP", restart)
+    process.on("SIGINT", quit)
+    process.on("SIGKILL", quitHard)
+  } catch (e) {
+    // Must be on Windows, waaa-waaah.
+  }
+
   process.on("exit", function () {
     if (!quitting) quitHard()
   })


### PR DESCRIPTION
Now the module can at least bootstrap itself without crashing on Windows.

Related: joyent/node#2904
