### PR TITLE
`args` property of config is being ignored

### DIFF
--- a/cluster-master.js
+++ b/cluster-master.js
@@ -60,6 +60,7 @@ function clusterMaster (config) {
   var masterConf = { exec: path.resolve(config.exec) }
   if (config.silent) masterConf.silent = true
   if (config.env) masterConf.env = config.env
+  if (config.args) masterConf.args = config.args
 
   cluster.setupMaster(masterConf)
 


### PR DESCRIPTION
The `args` property of the config object passed into clusterMaster to start the cluster is ignored. This PR fixes the issue. Here is a test case:

```
var cluster = require('cluster')
var clusterMaster = require('../cluster-master')

if (cluster.isMaster) {
  clusterMaster({
    exec: __filename,
    args: ['--some', 'args', 'here'],
    size: 2
  })
} else {
  var args = process.argv.slice(2)
  if (args.length > 0)
    console.log('Worker args:', args)
  else
    console.log('No worker args!')
}
```
