### PR TITLE
add REPL config, help, and document

### DIFF
--- a/README.md
+++ b/README.md
@@ -143,4 +143,5 @@ The REPL provides you with access to these objects or functions:
 * `states`      - map of id to worker states
 * `debug(a1)`   - output `a1` to stdout and all REPLs
 * `sock`        - this REPL socket'
+* `.exit`       - close this connection to the REPL
 

--- a/cluster-master.js
+++ b/cluster-master.js
@@ -152,7 +152,8 @@ function setupRepl () {
         'ages        - map of id to worker ages',
         'states      - map of id to worker states',
         'debug(a1)   - output `a1` to stdout and all REPLs',
-        'sock        - this REPL socket'
+        'sock        - this REPL socket',
+        '.exit       - close this connection to the REPL'
       ]
 
       var context = {


### PR DESCRIPTION
Provide ability to configure REPL via config.
- `repl` - where to have REPL listen, defaults to `env.CLUSTER_MASTER_REPL` || 'cluster-master-socket'
  - if `repl` is null or false - REPL is disabled and will not be started
  - if `repl` is string path - REPL will listen on unix domain socket to this path
  - if `repl` is an integer port - REPL will listen on TCP 0.0.0.0:port
  - if `repl` is an object with `address` and `port`, then REPL will listen on TCP address:PORT

Examples of configuring `repl`

``` javascript
var config = { repl: false }                       // disable REPL
var config = { repl: '/tmp/cluster-master-sock' }  // unix domain socket
var config = { repl: 3001 }                        // tcp socket 0.0.0.0:3001
var config = { repl: { address: '127.0.0.1', port: 3002 }}  // tcp 127.0.0.1:3002
```

Provide help command within the REPL

Document REPL use
