### PR TITLE
Override cluster size with environment variable.

### DIFF
--- a/cluster-master.js
+++ b/cluster-master.js
@@ -58,7 +58,7 @@ function clusterMaster (config) {
 
   onmessage = config.onMessage || config.onmessage
 
-  clusterSize = config.size || os.cpus().length
+  clusterSize = config.size || +process.env.CLUSTER_MASTER_SIZE || os.cpus().length
 
   minRestartAge = config.minRestartAge || minRestartAge
 


### PR DESCRIPTION
It's such a common requirement for ops to have the final say over the clustering, that configurability should be built in IMHO. Just like CLUSTER_MASTER_REPL.

Size is the most important setting for us, but the same argument might be used for other settings.
