### PR TITLE
Allow new env on restart

### DIFF
--- a/README.md
+++ b/README.md
@@ -58,10 +58,11 @@ clusterMaster.quitHard()
 Set the cluster size to `n`.  This will disconnect extra nodes and/or
 spin up new nodes, as needed.  Done by default on restarts.
 
-### clusterMaster.restart(cb)
+### clusterMaster.restart(env, cb)
 
-One by one, shut down nodes and spin up new ones.  Callback is called
-when finished.
+One by one, shut down nodes and spin up new ones.  New workers will
+receive `env`, instead of the envs passed in config.  Callback is called
+when finished. `env` and `cb` are optional.
 
 ### clusterMaster.quit()
 
@@ -129,7 +130,7 @@ The REPL provides you with access to these objects or functions:
 * `help`        - display these commands
 * `repl`        - access the REPL
 * `resize(n)`   - resize the cluster to `n` workers
-* `restart(cb)` - gracefully restart workers, cb is optional
+* `restart(env, cb)` - gracefully restart workers, env and cb are optional
 * `stop()`      - gracefully stop workers and master
 * `kill()`      - forcefully kill workers and master
 * `cluster`     - node.js cluster module

--- a/cluster-master.js
+++ b/cluster-master.js
@@ -148,7 +148,7 @@ function setupRepl () {
         'help        - display these commands',
         'repl        - access the REPL',
         'resize(n)   - resize the cluster to `n` workers',
-        'restart(cb) - gracefully restart workers, cb is optional',
+        'restart(env, cb) - gracefully restart workers, env and cb are optional',
         'stop()      - gracefully stop workers and master',
         'kill()      - forcefully kill workers and master',
         'cluster     - node.js cluster module',
@@ -304,13 +304,18 @@ function forkListener () {
   })
 }
 
-function restart (cb) {
+function restart (env_, cb) {
   if (restarting) {
     debug("Already restarting.  Cannot restart yet.")
     return
   }
 
   restarting = true
+
+  if (arguments.length == 1 && env_ && {}.toString.call(env_) == '[object Function]')
+    cb = env_, env_ = undefined
+
+  if (env_) env = env_
 
   // graceful restart.
   // all the existing workers get killed, and this


### PR DESCRIPTION
Sometimes we're restarting a cluster due to change in env, so we want to send a new env to each new worker.
