### PR TITLE
REPL emits `exit` not `end`

### DIFF
--- a/cluster-master.js
+++ b/cluster-master.js
@@ -210,7 +210,7 @@ function setupRepl () {
 
       sock.repl = r
 
-      r.on('end', function () {
+      r.on('exit', function () {
         connections --
         replEnded = true
         if (!ended) sock.end()


### PR DESCRIPTION
In both v0.8 and v0.10